### PR TITLE
feat: implement strip mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,26 @@ One of the following must be specified:
 - `--output-dir`: The output directory for the final zip file. The name of the zip file will be based on the project's
 name in the `pyproject.toml` file (with dashes replaced with underscores).
 
-## A Note on Reproducibility
+## Notes on Reproducibility
+
+### Timestamps
 
 The ZIP files generated adhere with [reproducible builds](https://reproducible-builds.org/docs/archives/). This means that file permissions and timestamps are modified inside the ZIP, such that the ZIP will have a deterministic hash. By default, the date is set to `1980-01-01`.
 
 Additionally, the tool respects the standardized `$SOURCE_DATE_EPOCH` [environment variable](https://reproducible-builds.org/docs/source-date-epoch/), which will allow you to set that date as needed.
 
 One important caveat is that ZIP files do not support files with timestamps earlier than `1980-01-01` inside them, due to MS-DOS compatibility. Therefore, the tool will throw a `SourceDateEpochError` is `$SOURCE_DATE_EPOCH` is below `315532800`.
+
+### Files with embedded full paths
+
+In testing, we found that several file types can leak information from the machine that generated the virtual environment.
+
+To get around this, the tool removes the following files:
+
+```gitignore
+**/__pycache/
+**/*.dist-info/direct_url.json
+**/*.dist-info/RECORD
+**/*.pyc
+**/*.pyo
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ addopts = """
 --capture=tee-sys
 """
 
+[tool.coverage.run]
+branch = true
+omit = ["*/tests/**"]
+
 [tool.pipx-install]
 poetry = "==2.1.1"
 poethepoet = "==0.33.1"

--- a/tests/test_package_python_function.py
+++ b/tests/test_package_python_function.py
@@ -67,7 +67,10 @@ def test_package_python_function(
             verify_file_reproducibility(zip.infolist(), expected_file_date_time=expected_date_time)
 
         for file in test_data.project_files:
-            assert (verify_dir / file.path).exists()
+            if file in test_data.files_excluded_from_bundle:
+                assert not (verify_dir / file.path).exists()
+            else:
+                assert (verify_dir / file.path).exists()
 
 @pytest.mark.parametrize(
     "src_epoch, expected_exception, expected_date_time",
@@ -131,5 +134,9 @@ def test_package_python_function_nested(
             with zipfile.ZipFile(inner_zip, "r") as izip:
                 izip.extractall(verify_dir)
                 verify_file_reproducibility(izip.infolist(), expected_file_date_time=expected_date_time)
+
                 for file in test_data_nested.project_files:
-                    assert (verify_dir / file.path).exists()
+                    if file in test_data_nested.files_excluded_from_bundle:
+                        assert not (verify_dir / file.path).exists()
+                    else:
+                        assert (verify_dir / file.path).exists()


### PR DESCRIPTION
Strips all `.py{c,o}`, `RECORD`, `direct_url.json`, and `__pycache__` files to ensure reproducible builds.