### PR TITLE
fix: make file ordering deterministic

### DIFF
--- a/package_python_function/packager.py
+++ b/package_python_function/packager.py
@@ -46,7 +46,8 @@ class Packager:
 
         with ZipFile(target_path, "w", ZIP_DEFLATED) as zip_file:
             def zip_dir(path: Path) -> None:
-                for item in path.iterdir():
+                # use sorted to make sure files are always written in a deterministic order
+                for item in sorted(path.iterdir(), key=lambda i: i.name):
                     if item.is_dir():
                         if item.name not in self.DIRS_TO_EXCLUDE:
                             zip_dir(item)


### PR DESCRIPTION
Fixes [an issue](https://upside-services.slack.com/archives/C04M70RA6UU/p1755005387682729) where file ordering would cause non-determinism in the zip files.
